### PR TITLE
chore: scaffold monorepo directories for wallet scanner

### DIFF
--- a/wallet-scanner/backend/README.md
+++ b/wallet-scanner/backend/README.md
@@ -1,0 +1,2 @@
+# Backend
+Placeholder for the FastAPI app.

--- a/wallet-scanner/frontend/README.md
+++ b/wallet-scanner/frontend/README.md
@@ -1,0 +1,2 @@
+# Frontend
+Placeholder for the Next.js app.


### PR DESCRIPTION
## Summary
- add wallet-scanner monorepo folder with frontend and backend sections
- document placeholders for Next.js and FastAPI apps

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b44f7b81b883249a1aea6d560af465