### PR TITLE
feat: add blockchair xpub API endpoint

### DIFF
--- a/wallet-scanner-frontend/pages/api/blockchair/xpub.ts
+++ b/wallet-scanner-frontend/pages/api/blockchair/xpub.ts
@@ -1,0 +1,18 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { fetchXpubDashboard } from '@/lib/blockchair'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { xpub } = req.query as { xpub?: string }
+  if (!xpub) {
+    res.status(400).json({ error: 'xpub is required' })
+    return
+  }
+  const key = (req.headers['x-api-key'] as string) || process.env.BLOCKCHAIR_API_KEY
+  try {
+    const data = await fetchXpubDashboard(xpub, { apiKey: key })
+    res.status(200).json(data)
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e)
+    res.status(502).json({ error: message })
+  }
+}

--- a/wallet-scanner-frontend/pages/api/scan/[id]/results.ts
+++ b/wallet-scanner-frontend/pages/api/scan/[id]/results.ts
@@ -1,14 +1,19 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const { id } = req.query
+  const { id } = req.query as { id: string }
   const base = process.env.BACKEND_INTERNAL_URL || 'http://localhost:8000'
   const url = `${base}/scan/${id}/results`
+  const init: RequestInit = {
+    method: req.method,
+    headers: { 'content-type': 'application/json', accept: 'application/json', cookie: req.headers.cookie || '' },
+  }
   try {
-    const r = await fetch(url, { headers: { accept: 'application/json', cookie: req.headers.cookie || '' } })
+    const r = await fetch(url, init)
     const text = await r.text()
     res.status(r.status).send(text)
-  } catch (e: any) {
-    res.status(502).json({ error: String(e?.message || e) })
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e)
+    res.status(502).json({ error: message })
   }
 }

--- a/wallet-scanner-frontend/pages/api/scan/[id]/status.ts
+++ b/wallet-scanner-frontend/pages/api/scan/[id]/status.ts
@@ -1,14 +1,19 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const { id } = req.query
+  const { id } = req.query as { id: string }
   const base = process.env.BACKEND_INTERNAL_URL || 'http://localhost:8000'
   const url = `${base}/scan/${id}/status`
+  const init: RequestInit = {
+    method: req.method,
+    headers: { 'content-type': 'application/json', accept: 'application/json', cookie: req.headers.cookie || '' },
+  }
   try {
-    const r = await fetch(url, { headers: { accept: 'application/json', cookie: req.headers.cookie || '' } })
+    const r = await fetch(url, init)
     const text = await r.text()
     res.status(r.status).send(text)
-  } catch (e: any) {
-    res.status(502).json({ error: String(e?.message || e) })
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e)
+    res.status(502).json({ error: message })
   }
 }


### PR DESCRIPTION
## Summary
- add Next.js API endpoint that calls Blockchair to fetch xpub data
- handle request method and headers in scan status and results API proxies
- report fetch errors as 502 from proxy

## Testing
- `npm run lint` (fails: Unexpected any)
- `npm run build` (fails: Unexpected any and other lint errors)


------
https://chatgpt.com/codex/tasks/task_b_68b74806bf9483249862ef155ecd0918