### PR TITLE
Add Nginx reverse proxy configuration

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -1,0 +1,28 @@
+server {
+  listen 80;
+  server_name _;
+  return 301 https://$host$request_uri;
+}
+server {
+  listen 443 ssl;
+  server_name _;
+  ssl_certificate     /etc/nginx/certs/fullchain.pem;
+  ssl_certificate_key /etc/nginx/certs/privkey.pem;
+
+  # API (FastAPI)
+  location /api/ {
+    proxy_pass http://backend:8000/;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+  }
+
+  # Frontend (Next.js)
+  location / {
+    proxy_pass http://frontend:3000/;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+  }
+}


### PR DESCRIPTION
## Summary
- configure Nginx to route HTTP traffic to backend and frontend services

## Testing
- `docker-compose up --build` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68b79df5fbec8324ae7a7bf5bea5de64