### PR TITLE
chore: remove frontend Dockerfile placeholder

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,8 +1,0 @@
-FROM node:20-alpine
-WORKDIR /app
-COPY package*.json ./
-RUN npm ci
-COPY . .
-RUN npm run build
-EXPOSE 3000
-CMD ["npm","run","start"]


### PR DESCRIPTION
## Summary
- remove placeholder Dockerfile from frontend so compose build fails until Dockerfiles are added

## Testing
- `node -v`
- `python3 --version`
- `docker --version`
- `docker-compose --version`
- `docker-compose up --build` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68b7a5bc0e108324b6bff721268411be